### PR TITLE
Added GA required endpoint parameter to the QnAMaker samples

### DIFF
--- a/blog-samples/Node/Blog-Qna-Attachments/app.js
+++ b/blog-samples/Node/Blog-Qna-Attachments/app.js
@@ -23,7 +23,8 @@ var bot = new builder.UniversalBot(connector);
 
 var recognizer = new builder_cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'Your-Qna-KnowledgeBase-ID', // process.env.QnAKnowledgebaseId, 
-    subscriptionKey: 'Your-Qna-KnowledgeBase-Password'}); //process.env.QnASubscriptionKey});
+    authKey: 'Your-Qna-KnowledgeBase-Password', //process.env.QnAAuthKey}),
+    endpointHostName: 'Your-Qna-KnowledgeBase-HostName'}); //process.env.QnAEndpointHostName});
 
 var basicQnAMakerDialog = new builder_cognitiveservices.QnAMakerDialog({
 recognizers: [recognizer],


### PR DESCRIPTION
The preview version of QnAMaker will be sustained until 7th November, so new users are using the GA already, therefore they are encountering problems with the current samples because they are not using the GA required endpoint parameter as stated here

So, I am adding the parameter to this sample.