### PR TITLE
Add deprecation notice to web-chat-speech

### DIFF
--- a/docs-samples/web-chat-speech/readme.md
+++ b/docs-samples/web-chat-speech/readme.md
@@ -1,10 +1,14 @@
-# Enable speech in the Web Chat control 
+# Please note: this sample is now deprecated
+
+See the [Speech updates](#speech-updates) section for more information.
+
+# Enable speech in the Web Chat control
 
   This is a sample HTML file which shows how to enable speech recognition and synthesis in the Web Chat control.
 
 ## Prerequisites
 
-  Before you run the sample, you need to have a Direct Line secret or token for the bot that you want to run using the Web Chat control. 
+  Before you run the sample, you need to have a Direct Line secret or token for the bot that you want to run using the Web Chat control.
   * See [Connect a bot to Direct Line](https://docs.microsoft.com/en-us/bot-framework/channel-connect-directline) for information on getting a Direct Line secret.
   * See [Generate a Direct Line token](https://docs.microsoft.com/en-us/bot-framework/rest-api/bot-framework-rest-direct-line-3-0-authentication) for information on exchanging the secret for a token.
 
@@ -15,8 +19,8 @@ To run the sample, you need to choose an option in the sample code, start a web 
 
 ### Choose a speech recognition option
 
-You have a few options to choose from for speech recognition. In `index.html`, find and uncomment the definition of `speechOptions` in the code that corresponds to the option you want to choose. 
-  
+You have a few options to choose from for speech recognition. In `index.html`, find and uncomment the definition of `speechOptions` in the code that corresponds to the option you want to choose.
+
   | Option | Description |
   |-----------|-------------|
   | No speech | The Web Chat control can be used with speech disabled. |
@@ -27,7 +31,7 @@ You have a few options to choose from for speech recognition. In `index.html`, f
 
 ### Start a web server
 One way to start a web server is to use `npm http-server` at a Node.js command prompt.
-  
+
 1. To install `http-server` globally so it can be run from the command line, run this command:
 
 ```
@@ -61,7 +65,7 @@ Web Chat should display in the browser window. Users interact with the voice int
 ![Web chat speech screenshot](./webchat-sample-speech.png)
 
 If the user types instead of speaking a response, Web Chat turns off the speech functionality and the bot gives only a textual response instead of speaking out loud. To re-enable the spoken response, the user can use the microphone to respond to the bot the next time. If the microphone is accepting input, it appears dark or filled-in. If it's grayed out, the user clicks on it to enable it.
-> **NOTE:** 
+> **NOTE:**
 > Google Chrome supports the browser speech recognizer. However, Chrome may block the microphone in the following cases:
 > * If the URL of the page that contains Web Chat begins with `http://` instead of `https://`.
 > * If the URL is a local file using the `file://` protocol instead of `http://localhost:8000`.
@@ -72,3 +76,24 @@ If the user types instead of speaking a response, Web Chat turns off the speech 
 * You can [download the source code](https://github.com/Microsoft/BotFramework-WebChat) for the web chat control on GitHub.
 * The [Bing Speech API documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/home) provides more information on the Bing Speech API.
 
+
+# Speech Updates
+
+As of October 2018, Bing Speech has been deprecated in favor of the new API, Cognitive Speech Services. Since Bing Speech is now in sunset, new keys can no longer be created. This sample is still available for Web Chat v3 users who already possess a Bing Speech API key.
+
+The Cognitive Speech Speech Services API is active and available for customer implementation in v4 of Web Chat. **Bing Speech and Speech Services are not interchangeable APIs**. There is currently no plan to make Cognitive Speech Services backwards-compatible with v3 of Web Chat. Please see below for a list of Web Chat v4 samples for Bing Speech (deprecated), Cognitive Speech Services, and Web Speech API.
+
+## Speech Samples list as of 2/14/2019
+
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Sample&nbsp;Name&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;| Description                                                                                                                                                                                  | Link                                                                                                                 |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| [`06.a.cognitive-services-bing-speech-js`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.a.cognitive-services-bing-speech-js)                                   | Introduces speech-to-text and text-to-speech ability using the (deprecated) Cognitive Services Bing Speech API and JavaScript.                                                                                                      | [Bing Speech with JS Demo](https://microsoft.github.io/BotFramework-WebChat/06.a.cognitive-services-bing-speech-js)  |
+| [`06.b.cognitive-services-bing-speech-react`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.b.cognitive-services-bing-speech-react)                             | Introduces speech-to-text and text-to-speech ability using the (deprecated) Cognitive Services Bing Speech API and React.                                                                                                           | [Bing Speech with React Demo](https://microsoft.github.io/BotFramework-WebChat/06.b.cognitive-services-bing-speech-react)|
+| [`06.c.cognitive-services-speech-services-js`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.c.cognitive-services-speech-services-js)                           | Introduces speech-to-text and text-to-speech ability using Cognitive Services Speech Services API.                                                                                                                                  | [Speech Services with JS Demo](https://microsoft.github.io/BotFramework-WebChat/6.c.cognitive-services-speech-services-js)|
+| [`06.d.speech-web-browser`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.d.speech-web-browser)                                                                 | Demonstrates how to implement text-to-speech using Web Chat's browser-based Web Speech API. (link to W3C standard in the sample)                                                                                                    | [Web Speech API Demo](https://microsoft.github.io/BotFramework-WebChat/06.d.speech-web-browser)                      |
+| [`06.e.cognitive-services-speech-services-with-lexical-result`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.e.cognitive-services-speech-services-with-lexical-result) | Demonstrates how to use lexical result from Cognitive Services Speech Services API.                                                                                                                                         | [Lexical Result Demo](https://microsoft.github.io/BotFramework-WebChat/06.e.cognitive-services-speech-services-with-lexical-result)|
+| [`06.f.hybrid-speech`](https://github.com/Microsoft/BotFramework-WebChat/tree/master/samples/06.f.hybrid-speech)                                                                           | Demonstrates how to use both browser-based Web Speech API for speech-to-text, and Cognitive Services Speech Services API for text-to-speech.                                                                                        | [Hybrid Speech Demo](https://microsoft.github.io/BotFramework-WebChat/06.f.hybrid-speech)                            |
+
+## Other resources
+- [Bing Speech Documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/home)
+- [Cognitive Speech Speech Services website](https://azure.microsoft.com/en-us/services/cognitive-services/speech-services/)


### PR DESCRIPTION
There as been an instance of a customer attempting to use the web-chat-speech sample with Cognitive Services Speech Services, which are incompatible. 
I have added a deprecation notice to inform our users about the Bing Speech to Cognitive Services Speech Services migration as well as links to our recent Web Chat samples. 

![image](https://user-images.githubusercontent.com/14900841/52812102-8e531200-304b-11e9-9f00-6e58c86ad627.png)
